### PR TITLE
Add Promise as a return type

### DIFF
--- a/src/content/reference/matchers/document.en.mdx
+++ b/src/content/reference/matchers/document.en.mdx
@@ -288,7 +288,15 @@ route(options:
     status?: any,
     title?: string,
     view?: any,
-  }  
+  } |
+  (request, context) => Promise<{
+    data?: object,
+    head?: any,
+    headers?: object,
+    status?: any,
+    title?: string,
+    view?: any,
+  }>
 )
 ```
 


### PR DESCRIPTION
The example demonstrates an async function. It seems like the type signature is missing a Promise return type.