### PR TITLE
Spelling fix

### DIFF
--- a/src/content/reference/react-components-hooks/document.en.mdx
+++ b/src/content/reference/react-components-hooks/document.en.mdx
@@ -317,7 +317,7 @@ function EmailForm() {
 
 ## `useView()`
 
-Silimar to [`useViewElement()`](#useviewelement), this hook can act in place of the `<View />` element. However, instead of returning a ready-to-go-element, it returns an object with the view's raw `content`, a `connect()` function that you'll need to wrap it with, and an assortment of other bits and pieces.
+Similar to [`useViewElement()`](#useviewelement), this hook can act in place of the `<View />` element. However, instead of returning a ready-to-go-element, it returns an object with the view's raw `content`, a `connect()` function that you'll need to wrap it with, and an assortment of other bits and pieces.
 
 ```typescript
 {


### PR DESCRIPTION
The word "similar" was misspelled as "Silimar"